### PR TITLE
URL Cleanup

### DIFF
--- a/deploy/docker/apache-hadoop-hdfs1.0.4-precise/Dockerfile
+++ b/deploy/docker/apache-hadoop-hdfs1.0.4-precise/Dockerfile
@@ -7,8 +7,8 @@ FROM ubuntu:precise
 VOLUME ["/data"]
 
 # Set correct source list
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise-updates main universe" >> /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ precise main universe" > /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ precise-updates main universe" >> /etc/apt/sources.list
 
 # install a few other useful packages plus Open Jdk 6
 RUN apt-get update && apt-get upgrade -y && apt-get install -y less openjdk-6-jre-headless net-tools vim-tiny sudo openssh-server iputils-ping python2.7

--- a/deploy/vagrant/core/init.sh
+++ b/deploy/vagrant/core/init.sh
@@ -8,7 +8,7 @@ sudo yum install -y -q wget
 # install maven
 if [ ! -f apache-maven-3.2.3-bin.tar.gz ]
 then
-    wget -q http://mirrors.gigenet.com/apache/maven/maven-3/3.2.3/binaries/apache-maven-3.2.3-bin.tar.gz 
+    wget -q https://mirrors.gigenet.com/apache/maven/maven-3/3.2.3/binaries/apache-maven-3.2.3-bin.tar.gz 
 fi
 
 if [ -f apache-maven-3.2.3-bin.tar.gz ]

--- a/deploy/vagrant/ufs/glusterfs/init.sh
+++ b/deploy/vagrant/ufs/glusterfs/init.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # install gluster
-sudo wget -q http://download.gluster.org/pub/gluster/glusterfs/3.5/LATEST/CentOS/glusterfs-epel.repo -O /etc/yum.repos.d/glusterfs-epel.repo
+sudo wget -q https://download.gluster.org/pub/gluster/glusterfs/3.5/LATEST/CentOS/glusterfs-epel.repo -O /etc/yum.repos.d/glusterfs-epel.repo
 sudo yum install -q -y glusterfs-server glusterfs-client
 
 # config gluster

--- a/deploy/vagrant/ufs/hadoop2/init.sh
+++ b/deploy/vagrant/ufs/hadoop2/init.sh
@@ -10,7 +10,7 @@ if [ ! -f hadoop-${HADOOP_VERSION}.tar.gz ]
 then
     # download hadoop
     echo "Downloading hadoop ${HADOOP_VERSION} ..." 
-    wget -q http://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
+    wget -q https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz
     tar xzf hadoop-${HADOOP_VERSION}.tar.gz  
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
   <description>Tachyon Project Parent</description>
   <name>Tachyon Project Parent</name>
-  <url>http://tachyonproject.org/</url>
+  <url>https://www.alluxio.org</url>
   <licenses>
     <license>
       <name>Apache License</name>
@@ -26,9 +26,9 @@
       <id>haoyuan</id>
       <name>Haoyuan Li</name>
       <email>haoyuan.li@gmail.com</email>
-      <url>http://www.cs.berkeley.edu/~haoyuan</url>
+      <url>https://www.cs.berkeley.edu/~haoyuan</url>
       <organization>U.C. Berkeley Computer Science</organization>
-      <organizationUrl>http://www.cs.berkeley.edu/</organizationUrl>
+      <organizationUrl>https://www.cs.berkeley.edu/</organizationUrl>
     </developer>
   </developers>
   <issueManagement>
@@ -92,7 +92,7 @@
       <!-- for Pivotal's distribution -->
       <id>spring-releases</id>
       <name>Spring Release Repository</name>
-      <url>http://repo.spring.io/libs-release</url>
+      <url>https://repo.spring.io/libs-release</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -103,7 +103,7 @@
     <repository>
       <id>HDPReleases</id>
       <name>HDP Releases</name>
-      <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+      <url>https://repo.hortonworks.com/content/repositories/releases/</url>
       <layout>default</layout>
       <releases>
         <enabled>true</enabled>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://archive.ubuntu.com/ubuntu (301) could not be migrated:  
   ([https](https://archive.ubuntu.com/ubuntu) result AnnotatedConnectException).
* http://repository.mapr.com/maven (404) could not be migrated:  
   ([https](https://repository.mapr.com/maven) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://archive.apache.org/dist/hadoop/common/hadoop- (404) migrated to:  
  https://archive.apache.org/dist/hadoop/common/hadoop- ([https](https://archive.apache.org/dist/hadoop/common/hadoop-) result 404).
* http://download.gluster.org/pub/gluster/glusterfs/3.5/LATEST/CentOS/glusterfs-epel.repo (301) migrated to:  
  https://download.gluster.org/pub/gluster/glusterfs/3.5/LATEST/CentOS/glusterfs-epel.repo ([https](https://download.gluster.org/pub/gluster/glusterfs/3.5/LATEST/CentOS/glusterfs-epel.repo) result 404).
* http://mirrors.gigenet.com/apache/maven/maven-3/3.2.3/binaries/apache-maven-3.2.3-bin.tar.gz (404) migrated to:  
  https://mirrors.gigenet.com/apache/maven/maven-3/3.2.3/binaries/apache-maven-3.2.3-bin.tar.gz ([https](https://mirrors.gigenet.com/apache/maven/maven-3/3.2.3/binaries/apache-maven-3.2.3-bin.tar.gz) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.hortonworks.com/content/repositories/releases/ migrated to:  
  https://repo.hortonworks.com/content/repositories/releases/ ([https](https://repo.hortonworks.com/content/repositories/releases/) result 200).
* http://tachyonproject.org/ (301) migrated to:  
  https://www.alluxio.org ([https](https://tachyonproject.org/) result 200).
* http://www.cs.berkeley.edu/ migrated to:  
  https://www.cs.berkeley.edu/ ([https](https://www.cs.berkeley.edu/) result 301).
* http://www.cs.berkeley.edu/~haoyuan migrated to:  
  https://www.cs.berkeley.edu/~haoyuan ([https](https://www.cs.berkeley.edu/~haoyuan) result 301).
* http://repo.spring.io/libs-release migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/xsd/maven-4.0.0.xsd
* http://www.w3.org/2001/XMLSchema-instance