### PR TITLE
URL Cleanup

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                      http://maven.apache.org/xsd/maven-4.0.0.xsd">
+                      https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.tachyonproject</groupId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.tachyonproject</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.tachyonproject</groupId>

--- a/core/src/main/resources/tachyon_checks.xml
+++ b/core/src/main/resources/tachyon_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
     "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+    "https://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!--
 
@@ -11,7 +11,7 @@
        https://google-styleguide.googlecode.com/svn-history/r130/trunk/javaguide.html
        
     Checkstyle is very configurable. Be sure to read the documentation at
-    http://checkstyle.sf.net (or in your downloaded distribution).
+    http://checkstyle.sourceforge.net/ (or in your downloaded distribution).
 
     Most Checks are configurable, be sure to consult the documentation.
 
@@ -27,7 +27,7 @@
   <property name="severity" value="error"/>
 
   <!-- Checks for whitespace                               -->
-  <!-- See http://checkstyle.sf.net/config_whitespace.html -->
+  <!-- See http://checkstyle.sourceforge.net/config_whitespace.html -->
   <module name="FileTabCharacter">
     <property name="eachLine" value="true"/>
   </module>
@@ -47,7 +47,7 @@
     </module>
     <module name="LineLength">
       <property name="max" value="100"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+      <property name="ignorePattern" value="^package.*|^import.*|a href|href|https://|https://|ftp://"/>
     </module>
     <module name="AvoidStarImport"/>
     <module name="OneTopLevelClass"/>

--- a/core/src/main/resources/tachyon_checkstyle_suppressions.xml
+++ b/core/src/main/resources/tachyon_checkstyle_suppressions.xml
@@ -2,7 +2,7 @@
 
 <!DOCTYPE suppressions PUBLIC
     "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <!-- TODO: This is needed to excuse Tachyon Configuration members' name from being checked -->
 <!-- because the members are define using all upper case. -->

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.tachyonproject</groupId>
   <artifactId>tachyon-parent</artifactId>
@@ -8,7 +8,7 @@
   <packaging>pom</packaging>
   <description>Tachyon Project Parent</description>
   <name>Tachyon Project Parent</name>
-  <url>http://tachyonproject.org/</url>
+  <url>https://www.alluxio.org</url>
   <licenses>
     <license>
       <name>Apache License</name>
@@ -26,9 +26,9 @@
       <id>haoyuan</id>
       <name>Haoyuan Li</name>
       <email>haoyuan.li@gmail.com</email>
-      <url>http://www.cs.berkeley.edu/~haoyuan</url>
+      <url>https://www.cs.berkeley.edu/~haoyuan</url>
       <organization>U.C. Berkeley Computer Science</organization>
-      <organizationUrl>http://www.cs.berkeley.edu/</organizationUrl>
+      <organizationUrl>https://www.cs.berkeley.edu/</organizationUrl>
     </developer>
   </developers>
   <issueManagement>
@@ -92,7 +92,7 @@
       <!-- for Pivotal's distribution -->
       <id>spring-releases</id>
       <name>Spring Release Repository</name>
-      <url>http://repo.spring.io/libs-release</url>
+      <url>https://repo.spring.io/libs-release</url>
       <releases>
         <enabled>true</enabled>
       </releases>
@@ -103,7 +103,7 @@
     <repository>
       <id>HDPReleases</id>
       <name>HDP Releases</name>
-      <url>http://repo.hortonworks.com/content/repositories/releases/</url>
+      <url>https://repo.hortonworks.com/content/repositories/releases/</url>
       <layout>default</layout>
       <releases>
         <enabled>true</enabled>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://checkstyle.sf.net (301) with 1 occurrences could not be migrated:  
   ([https](https://checkstyle.sf.net) result AnnotatedConnectException).
* http://checkstyle.sf.net/config_whitespace.html (301) with 1 occurrences could not be migrated:  
   ([https](https://checkstyle.sf.net/config_whitespace.html) result AnnotatedConnectException).
* http://repository.mapr.com/maven (404) with 1 occurrences could not be migrated:  
   ([https](https://repository.mapr.com/maven) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://|https://|ftp:// (UnknownHostException) with 1 occurrences migrated to:  
  https://|https://|ftp:// ([https](https://|https://|ftp://) result UnknownHostException).
* http://www.puppycrawl.com/dtds/configuration_1_3.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/configuration_1_3.dtd ([https](https://www.puppycrawl.com/dtds/configuration_1_3.dtd) result 404).
* http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/maven-4.0.0.xsd with 4 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://repo.hortonworks.com/content/repositories/releases/ with 1 occurrences migrated to:  
  https://repo.hortonworks.com/content/repositories/releases/ ([https](https://repo.hortonworks.com/content/repositories/releases/) result 200).
* http://tachyonproject.org/ (301) with 1 occurrences migrated to:  
  https://www.alluxio.org ([https](https://tachyonproject.org/) result 200).
* http://www.cs.berkeley.edu/ with 1 occurrences migrated to:  
  https://www.cs.berkeley.edu/ ([https](https://www.cs.berkeley.edu/) result 301).
* http://www.cs.berkeley.edu/~haoyuan with 1 occurrences migrated to:  
  https://www.cs.berkeley.edu/~haoyuan ([https](https://www.cs.berkeley.edu/~haoyuan) result 301).
* http://repo.spring.io/libs-release with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release ([https](https://repo.spring.io/libs-release) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 8 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences